### PR TITLE
orderMessage에 productStock이 아닌 orderStock 전송, 결제성공후 트랜잭션 처리

### DIFF
--- a/order/src/main/java/async/example/service/OrderService.java
+++ b/order/src/main/java/async/example/service/OrderService.java
@@ -152,7 +152,7 @@ public class OrderService {
         OrderMessage orderMessage = OrderMessage.builder()
             .logId(orderLog.getId())
             .productId(product.getId())
-            .stock(product.getStock())
+            .stock(orderRequest.getStock())
             .totalPrice(totalPrice)
             .build();
 
@@ -168,13 +168,13 @@ public class OrderService {
         orderLogRepository.save(orderLog);
     }
 
+    @Transactional
     public void handlePaymentResult(OrderMessage message) {
         OrderLog orderLog = orderLogRepository.findById(message.getLogId()).orElseThrow(() -> new RuntimeException("주문내역이 존재하지 않습니다."));
         orderLog.setStatus(OrderStatus.COMPLETE);
         Product product = productRepository.findById(message.getProductId())
             .orElseThrow(() -> new RuntimeException("존재하지 않는 상품입니다."));
         product.updateStock(message.getStock());
-        productRepository.save(product);
         log.info("======================");
         log.info("주문 결과 처리 완료");
     }


### PR DESCRIPTION
1. 
메세지에 product.stock이 전달되어 결제 후 product.stock만큼 차감되는 문제가 있어서 수정

2. 
handlePaymentResult에서 Order.setStatus가 DB에 반영되지 않아서 @Transactional 어노테이션을 추가했고, 
어노테이션을 추가했더니 product.updateStock과 productRepository.save 때문에 DB에 두번 적용되어 후자를 삭제했습니다.