### PR TITLE
Kafka Version 메세지 큐.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '2.5.6'
+    id 'org.springframework.boot' version '2.3.2.RELEASE'
     id("io.spring.dependency-management") version "1.0.11.RELEASE"
     id 'java'
 }

--- a/order/build.gradle
+++ b/order/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     implementation project(':message')
     // rabbit
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-stream-rabbit', version: '3.0.7.RELEASE'
+    // kafka
+    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-stream-kafka', version: '3.0.7.RELEASE'
 
 }
 

--- a/order/src/main/java/async/example/controller/OrderController.java
+++ b/order/src/main/java/async/example/controller/OrderController.java
@@ -45,7 +45,13 @@ public class OrderController {
     }
 
     @PostMapping("/async/mq")
-    public ResponseEntity<String> orderAsnycByMessageQueue(@RequestBody OrderRequest orderRequest) { // 비동기 요청 후 처리 결과를 받는 API 입니다.
+    public ResponseEntity<String> orderAsyncByMessageQueue(@RequestBody OrderRequest orderRequest) { // 비동기 요청 후 처리 결과를 받는 API 입니다.
+        orderService.orderAsyncMessaging(orderRequest);
+        return new ResponseEntity<>("주문 요청이 생성되었습니다.", HttpStatus.OK);
+    }
+
+    @PostMapping("/async/kafka")
+    public ResponseEntity<String> orderAsyncByKafka(@RequestBody OrderRequest orderRequest) {
         orderService.orderAsyncMessaging(orderRequest);
         return new ResponseEntity<>("주문 요청이 생성되었습니다.", HttpStatus.OK);
     }

--- a/order/src/main/resources/application-stream-kafka.yml
+++ b/order/src/main/resources/application-stream-kafka.yml
@@ -1,0 +1,22 @@
+spring:
+  kafka:
+    producer:
+      bootstrap-servers: localhost:9092
+  cloud:
+    stream:
+      default:
+        contentType: application/json
+      bindings:
+        publishChannel:
+          binder: kafka
+          destination: payrequest
+          durableSubscribtion: true
+          producer:
+            required-groups: test-queue
+
+        resultChannel:
+          binder: kafka
+          destination: resultChannel
+          durableSubscribtion: true
+          producer:
+            required-groups: test-queue

--- a/order/src/main/resources/application.yml
+++ b/order/src/main/resources/application.yml
@@ -3,15 +3,12 @@ server:
 spring:
   jpa:
     hibernate:
-      ddlAuto: create
+      ddlAuto: update
     show-sql: true
-    defer-datasource-initialization: true
   datasource:
-    url: jdbc:mysql://localhost:21746/async?useSSL=false&useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
+    url: jdbc:mysql://localhost:3306/async?useSSL=false&useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
     username: root
     password: 1234
-  sql:
-    init:
-      mode: always
+    initialization-mode: always
   profiles:
     active: stream-rabbitmq

--- a/order/src/main/resources/application.yml
+++ b/order/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     show-sql: true
     defer-datasource-initialization: true
   datasource:
-    url: jdbc:mysql://localhost:21746/async?useSSL=false&useUnicode=true&characterEncoding=utf8
+    url: jdbc:mysql://localhost:21746/async?useSSL=false&useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
     username: root
     password: 1234
   sql:

--- a/payment/build.gradle
+++ b/payment/build.gradle
@@ -30,6 +30,9 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation project(':message')
+    //rabbit
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-stream-rabbit', version: '3.0.7.RELEASE'
+    // kafka
+    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-stream-kafka', version: '3.0.7.RELEASE'
 
 }

--- a/payment/src/main/resources/application-stream-kafka.yml
+++ b/payment/src/main/resources/application-stream-kafka.yml
@@ -1,0 +1,24 @@
+spring:
+  kafka:
+    producer:
+      bootstrap-servers: localhost:9092
+  cloud:
+    stream:
+      default:
+        contentType: application/json
+      bindings:
+        subscribeChannel:
+          binder: kafka
+          destination: payrequest
+          producer:
+            required-groups: test-queue
+        resultCheannel:
+          binder: kafka
+          destination: resultChannel
+          producer:
+            required-groups: test-queue
+        deadLetterChannel:
+          binder: kafka
+          destination: dead-letter-queue
+          producer:
+            required-groups: test-queue

--- a/payment/src/main/resources/application.yml
+++ b/payment/src/main/resources/application.yml
@@ -3,3 +3,6 @@ server:
 spring:
   profiles:
     active: stream-rabbitmq
+  cloud:
+    stream:
+      default-binder: rabbit


### PR DESCRIPTION
Kafka를 활용한 메세지 큐를 구성하였습니다.

Spring-Boot Version은 호환성 문제로 2.5.6 -> 2.3.2.RELEASE 변경하였습니다.

RabbitMQ와 동일한 서버시 로직을 사용하고 Controller는 따로 만들어줬습니다.

DB TimeZone문제가 발생하여 Asia/Seoul로 Time을 맞추어 줬습니다.

Boot Version변경으로 2.5.x버전 이후부터 defer-datasource-initialization: true 옵션이 적용된다고 합니다.
그래서 sql.init도 적용이 안되어 삭제하였습니다.