### PR TITLE
문항마다 service 분리, 공통 메소드 정리

### DIFF
--- a/order/src/main/java/async/example/controller/OrderController.java
+++ b/order/src/main/java/async/example/controller/OrderController.java
@@ -26,12 +26,6 @@ public class OrderController {
         return new ResponseEntity<>("주문 완료", HttpStatus.OK);
     }
 
-    @PostMapping("/sync/v2")
-    public ResponseEntity<String> orderV2(@RequestBody OrderRequest orderRequest) { // 결제가 성공하는 것을 보장하는 동기 요청 입니다.
-        orderService.orderUntilSucceed(orderRequest);
-        return new ResponseEntity<>("주문 완료", HttpStatus.OK);
-    }
-
     @PostMapping("/async/v1")
     public ResponseEntity<String> orderAsync(@RequestBody OrderRequest orderRequest) { //비동기 요청입니다.
         orderService.orderAsync(orderRequest);

--- a/order/src/main/java/async/example/controller/OrderController.java
+++ b/order/src/main/java/async/example/controller/OrderController.java
@@ -1,6 +1,9 @@
 package async.example.controller;
 
+import async.example.service.OrderAsyncService;
+import async.example.service.OrderMqService;
 import async.example.service.OrderService;
+import async.example.service.OrderSyncService;
 import lombok.RequiredArgsConstructor;
 import message.OrderRequest;
 import org.springframework.http.HttpStatus;
@@ -16,10 +19,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class OrderController {
 
     private final OrderService orderService;
+    private final OrderSyncService orderSyncService;
+    private final OrderAsyncService orderAsyncService;
+    private final OrderMqService orderMqService;
 
     @PostMapping("/sync/v1")
     public ResponseEntity<String> orderV1(@RequestBody OrderRequest orderRequest) { // 단순한 동기 요청입니다.
-        boolean result = orderService.orderSync(orderRequest);
+        boolean result = orderSyncService.orderSync(orderRequest);
         if (result == Boolean.FALSE) {
             return new ResponseEntity<>("주문 실패", HttpStatus.CONFLICT);
         }
@@ -28,13 +34,13 @@ public class OrderController {
 
     @PostMapping("/async/v1")
     public ResponseEntity<String> orderAsync(@RequestBody OrderRequest orderRequest) { //비동기 요청입니다.
-        orderService.orderAsync(orderRequest);
+        orderAsyncService.orderAsync(orderRequest);
         return new ResponseEntity<>("주문 요청이 생성되었습니다.", HttpStatus.OK);
     }
 
     @PostMapping("/async/mq")
     public ResponseEntity<String> orderAsyncByMessageQueue(@RequestBody OrderRequest orderRequest) { // 메세지 큐를 통한 비동기 요청입니다.
-        orderService.orderAsyncMessaging(orderRequest);
+        orderMqService.orderAsyncMessaging(orderRequest);
         return new ResponseEntity<>("주문 요청이 생성되었습니다.", HttpStatus.OK);
     }
 }

--- a/order/src/main/java/async/example/service/CommonService.java
+++ b/order/src/main/java/async/example/service/CommonService.java
@@ -7,7 +7,6 @@ import async.example.domain.entity.repository.ProductRepository;
 import async.example.domain.enumtype.OrderStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.criterion.Order;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +21,11 @@ public class CommonService {
     public Product findProduct(int productId) {
         return productRepository.findById(productId)
                 .orElseThrow(() -> new RuntimeException("존재하지 않는 상품입니다."));
+    }
+
+    public OrderLog findOrderLog(int orderId) {
+        return orderLogRepository.findById(orderId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 주문내역입니다."));
     }
 
     @Transactional
@@ -46,6 +50,8 @@ public class CommonService {
         log.info("결제에 성공했습니다.");
         orderLog.setStatus(OrderStatus.COMPLETE);
         product.updateStock(requestStock);
+        productRepository.save(product);
+        orderLogRepository.save(orderLog);
     }
 
     void saveFailOrder(OrderLog orderLog) {

--- a/order/src/main/java/async/example/service/CommonService.java
+++ b/order/src/main/java/async/example/service/CommonService.java
@@ -1,0 +1,56 @@
+package async.example.service;
+
+import async.example.domain.entity.OrderLog;
+import async.example.domain.entity.Product;
+import async.example.domain.entity.repository.OrderLogRepository;
+import async.example.domain.entity.repository.ProductRepository;
+import async.example.domain.enumtype.OrderStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.criterion.Order;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CommonService {
+
+    private final ProductRepository productRepository;
+    private final OrderLogRepository orderLogRepository;
+
+    public Product findProduct(int productId) {
+        return productRepository.findById(productId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 상품입니다."));
+    }
+
+    @Transactional
+    OrderLog checkStockAndCreateOrder(Product product, int requestStock, OrderStatus status) {
+        if (product.getStock() < requestStock) {
+            log.error("재고가 부족합니다.");
+            throw new RuntimeException("재고가 부족합니다.");
+        }
+        log.info("============주문 내역 생성==========");
+        OrderLog orderLog = OrderLog.builder()
+                .productId(product.getId())
+                .productName(product.getName())
+                .productPrice(product.getPrice())
+                .orderStock(requestStock)
+                .status(status)
+                .build();
+        return orderLogRepository.save(orderLog);
+    }
+
+    @Transactional
+    void updateStockAndSaveOrder(Product product, int requestStock, OrderLog orderLog) {
+        log.info("결제에 성공했습니다.");
+        orderLog.setStatus(OrderStatus.COMPLETE);
+        product.updateStock(requestStock);
+    }
+
+    void saveFailOrder(OrderLog orderLog) {
+        log.info("결제에 실패했습니다.");
+        orderLog.setStatus(OrderStatus.FAILED);
+    }
+
+}

--- a/order/src/main/java/async/example/service/OrderAsyncService.java
+++ b/order/src/main/java/async/example/service/OrderAsyncService.java
@@ -6,6 +6,7 @@ import async.example.domain.entity.repository.OrderLogRepository;
 import async.example.domain.entity.repository.ProductRepository;
 import async.example.domain.enumtype.OrderStatus;
 import async.example.publish.binder.OrderBinder;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import message.OrderRequest;
 import org.springframework.http.ResponseEntity;
@@ -14,18 +15,14 @@ import org.springframework.web.client.RestTemplate;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class OrderAsyncService {
     RestTemplate restTemplate = new RestTemplate();
     private static final String paymentUrl = "http://localhost:20002/payment";
+
     private final OrderLogRepository orderLogRepository;
     private final ProductRepository productRepository;
 
-    public OrderAsyncService(
-        OrderLogRepository orderLogRepository,
-        ProductRepository productRepository, OrderBinder orderBinder) {
-        this.orderLogRepository = orderLogRepository;
-        this.productRepository = productRepository;
-    }
 
     public void orderAsync(OrderRequest orderRequest) {
         Product product = productRepository.findById(orderRequest.getProductId())

--- a/order/src/main/java/async/example/service/OrderAsyncService.java
+++ b/order/src/main/java/async/example/service/OrderAsyncService.java
@@ -5,7 +5,6 @@ import async.example.domain.entity.Product;
 import async.example.domain.entity.repository.OrderLogRepository;
 import async.example.domain.entity.repository.ProductRepository;
 import async.example.domain.enumtype.OrderStatus;
-import async.example.publish.binder.OrderBinder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import message.OrderRequest;

--- a/order/src/main/java/async/example/service/OrderAsyncService.java
+++ b/order/src/main/java/async/example/service/OrderAsyncService.java
@@ -2,16 +2,11 @@ package async.example.service;
 
 import async.example.domain.entity.OrderLog;
 import async.example.domain.entity.Product;
-import async.example.domain.entity.repository.OrderLogRepository;
-import async.example.domain.entity.repository.ProductRepository;
 import async.example.domain.enumtype.OrderStatus;
-import async.example.publish.binder.OrderBinder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import message.OrderMessage;
 import message.OrderRequest;
 import org.springframework.http.ResponseEntity;
-import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
@@ -24,8 +19,6 @@ public class OrderAsyncService {
     private static final String paymentUrl = "http://localhost:20002/payment";
 
     private final CommonService commonService;
-    private final OrderLogRepository orderLogRepository;
-    private final ProductRepository productRepository;
 
     @Transactional
     public void orderAsync(OrderRequest orderRequest) {

--- a/order/src/main/java/async/example/service/OrderAsyncService.java
+++ b/order/src/main/java/async/example/service/OrderAsyncService.java
@@ -1,0 +1,83 @@
+package async.example.service;
+
+import async.example.domain.entity.OrderLog;
+import async.example.domain.entity.Product;
+import async.example.domain.entity.repository.OrderLogRepository;
+import async.example.domain.entity.repository.ProductRepository;
+import async.example.domain.enumtype.OrderStatus;
+import async.example.publish.binder.OrderBinder;
+import lombok.extern.slf4j.Slf4j;
+import message.OrderRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@Slf4j
+public class OrderAsyncService {
+    RestTemplate restTemplate = new RestTemplate();
+    private static final String paymentUrl = "http://localhost:20002/payment";
+    private final OrderLogRepository orderLogRepository;
+    private final ProductRepository productRepository;
+
+    public OrderAsyncService(
+        OrderLogRepository orderLogRepository,
+        ProductRepository productRepository, OrderBinder orderBinder) {
+        this.orderLogRepository = orderLogRepository;
+        this.productRepository = productRepository;
+    }
+
+    public void orderAsync(OrderRequest orderRequest) {
+        Product product = productRepository.findById(orderRequest.getProductId())
+            .orElseThrow(() -> new RuntimeException("존재하지 않는 상품입니다."));
+
+        stockCheck(product.getStock(), orderRequest.getStock());
+
+        log.info("주문 생성중");
+        OrderLog orderLog = OrderLog.builder()
+            .productId(product.getId())
+            .productName(product.getName())
+            .productPrice(product.getPrice())
+            .orderStock(orderRequest.getStock())
+            .status(OrderStatus.ASYNC_ORDER_REQUEST_COMPLETE)
+            .build();
+        orderLogRepository.save(orderLog);
+        log.info("==========주문 내역 생성=============");
+        Long totalPrice = product.getPrice() * orderRequest.getStock();
+        new Thread( () ->
+        {
+            ResponseEntity<String> response = restTemplate.postForEntity(paymentUrl, totalPrice, String.class);
+            if (response.getBody().equals("실패")) {
+                log.error("=================결제 실패===============");
+                log.info("실패 내역- 요청ID: {}, 상품ID:{} , 금액: {}", orderLog.getId(), orderLog.getProductId(), totalPrice);
+            } else {
+                log.error("=================결제 성공===============");
+                orderAsyncResult(orderLog.getId());
+            }
+        }).start();
+        log.info("결제 요청 완료");
+    }
+
+    // 비동기 요청 완료 후
+    public void orderAsyncResult(Integer orderId) {
+        OrderLog orderLog = orderLogRepository.findById(orderId)
+            .orElseThrow(() -> new RuntimeException("존재하지 않는 주문내역입니다."));
+        log.info("주문 요청 처리 완료");
+        Product product = productRepository.findById(orderLog.getProductId())
+            .orElseThrow(() -> new RuntimeException("존재하지 않는 상품입니다."));
+        log.info("재고 차감 중");
+        log.info("========================");
+        orderLog.setStatus(OrderStatus.COMPLETE);
+        product.updateStock(orderLog.getOrderStock());
+        productRepository.save(product);
+        orderLogRepository.save(orderLog);
+        log.info("주문 상태 변경 및 재고 차감 완료");
+    }
+
+    private void stockCheck(Integer prodStock, Integer reqStock) {
+        if (prodStock < reqStock) {
+            log.error("재고가 부족합니다.");
+            throw new RuntimeException("재고가 부족합니다.");
+        }
+    }
+}

--- a/order/src/main/java/async/example/service/OrderMqService.java
+++ b/order/src/main/java/async/example/service/OrderMqService.java
@@ -1,0 +1,84 @@
+package async.example.service;
+
+import async.example.domain.entity.OrderLog;
+import async.example.domain.entity.Product;
+import async.example.domain.entity.repository.OrderLogRepository;
+import async.example.domain.entity.repository.ProductRepository;
+import async.example.domain.enumtype.OrderStatus;
+import async.example.publish.binder.OrderBinder;
+import lombok.extern.slf4j.Slf4j;
+import message.OrderMessage;
+import message.OrderRequest;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@Slf4j
+public class OrderMqService {
+    RestTemplate restTemplate = new RestTemplate();
+    private static final String paymentUrl = "http://localhost:20002/payment";
+    private final OrderLogRepository orderLogRepository;
+    private final ProductRepository productRepository;
+    private final OrderBinder orderBinder;
+
+    public OrderMqService(
+        OrderLogRepository orderLogRepository,
+        ProductRepository productRepository, OrderBinder orderBinder) {
+        this.orderLogRepository = orderLogRepository;
+        this.productRepository = productRepository;
+        this.orderBinder = orderBinder;
+    }
+
+    public void orderAsyncMessaging(OrderRequest orderRequest) {
+        Product product = productRepository.findById(orderRequest.getProductId())
+            .orElseThrow(() -> new RuntimeException("존재하지 않는 상품입니다."));
+        OrderLog orderLog = OrderLog.builder()
+            .productId(product.getId())
+            .productName(product.getName())
+            .productPrice(product.getPrice())
+            .orderStock(orderRequest.getStock())
+            .status(OrderStatus.WAITING_FOR_PAYMENT)
+            .build();
+        orderLogRepository.save(orderLog);
+        Long totalPrice = product.getPrice() * orderRequest.getStock();
+        OrderMessage orderMessage = OrderMessage.builder()
+            .logId(orderLog.getId())
+            .productId(product.getId())
+            .stock(orderRequest.getStock())
+            .totalPrice(totalPrice)
+            .build();
+
+        boolean sendResult = orderBinder.channel().send(MessageBuilder.withPayload(orderMessage).build());
+        if (!sendResult) {
+            log.error("내역 전송 실패");
+            throw new RuntimeException("Dead Queue 전송 실패");
+        }
+
+        log.info("주문 요청 처리 완료");
+        log.info("========================");
+        orderLog.setStatus(OrderStatus.ASYNC_ORDER_REQUEST_COMPLETE);
+        orderLogRepository.save(orderLog);
+    }
+
+    // 메세지 큐로 받은 결제의 결과를 처리하는 함수
+    @Transactional
+    public void handlePaymentResult(OrderMessage message) {
+        OrderLog orderLog = orderLogRepository.findById(message.getLogId()).orElseThrow(() -> new RuntimeException("주문내역이 존재하지 않습니다."));
+        orderLog.setStatus(OrderStatus.COMPLETE);
+        Product product = productRepository.findById(message.getProductId())
+            .orElseThrow(() -> new RuntimeException("존재하지 않는 상품입니다."));
+        product.updateStock(message.getStock());
+        log.info("======================");
+        log.info("주문 결과 처리 완료");
+    }
+
+
+    private void stockCheck(Integer prodStock, Integer reqStock) {
+        if (prodStock < reqStock) {
+            log.error("재고가 부족합니다.");
+            throw new RuntimeException("재고가 부족합니다.");
+        }
+    }
+}

--- a/order/src/main/java/async/example/service/OrderMqService.java
+++ b/order/src/main/java/async/example/service/OrderMqService.java
@@ -3,7 +3,6 @@ package async.example.service;
 import async.example.domain.entity.OrderLog;
 import async.example.domain.entity.Product;
 import async.example.domain.entity.repository.OrderLogRepository;
-import async.example.domain.entity.repository.ProductRepository;
 import async.example.domain.enumtype.OrderStatus;
 import async.example.publish.binder.OrderBinder;
 import lombok.RequiredArgsConstructor;
@@ -20,21 +19,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderMqService {
 
     private final OrderLogRepository orderLogRepository;
-    private final ProductRepository productRepository;
     private final OrderBinder orderBinder;
+    private final CommonService commonService;
 
     public void orderAsyncMessaging(OrderRequest orderRequest) {
-        Product product = productRepository.findById(orderRequest.getProductId())
-            .orElseThrow(() -> new RuntimeException("존재하지 않는 상품입니다."));
-        OrderLog orderLog = OrderLog.builder()
-            .productId(product.getId())
-            .productName(product.getName())
-            .productPrice(product.getPrice())
-            .orderStock(orderRequest.getStock())
-            .status(OrderStatus.WAITING_FOR_PAYMENT)
-            .build();
-        orderLogRepository.save(orderLog);
-        Long totalPrice = product.getPrice() * orderRequest.getStock();
+        // before payment
+        Product product = commonService.findProduct(orderRequest.getProductId());
+        int requestStock = orderRequest.getStock();
+        Long totalPrice = product.getPrice() * requestStock;
+        OrderLog orderLog = commonService.checkStockAndCreateOrder(product, requestStock, OrderStatus.WAITING_FOR_PAYMENT);
+
         OrderMessage orderMessage = OrderMessage.builder()
             .logId(orderLog.getId())
             .productId(product.getId())
@@ -57,20 +51,12 @@ public class OrderMqService {
     // 메세지 큐로 받은 결제의 결과를 처리하는 함수
     @Transactional
     public void handlePaymentResult(OrderMessage message) {
-        OrderLog orderLog = orderLogRepository.findById(message.getLogId()).orElseThrow(() -> new RuntimeException("주문내역이 존재하지 않습니다."));
+        OrderLog orderLog = commonService.findOrderLog(message.getLogId());
         orderLog.setStatus(OrderStatus.COMPLETE);
-        Product product = productRepository.findById(message.getProductId())
-            .orElseThrow(() -> new RuntimeException("존재하지 않는 상품입니다."));
+        Product product = commonService.findProduct(orderLog.getProductId());
         product.updateStock(message.getStock());
         log.info("======================");
         log.info("주문 결과 처리 완료");
     }
 
-
-    private void stockCheck(Integer prodStock, Integer reqStock) {
-        if (prodStock < reqStock) {
-            log.error("재고가 부족합니다.");
-            throw new RuntimeException("재고가 부족합니다.");
-        }
-    }
 }

--- a/order/src/main/java/async/example/service/OrderMqService.java
+++ b/order/src/main/java/async/example/service/OrderMqService.java
@@ -13,7 +13,6 @@ import message.OrderRequest;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
 
 @Service
 @Slf4j

--- a/order/src/main/java/async/example/service/OrderMqService.java
+++ b/order/src/main/java/async/example/service/OrderMqService.java
@@ -6,6 +6,7 @@ import async.example.domain.entity.repository.OrderLogRepository;
 import async.example.domain.entity.repository.ProductRepository;
 import async.example.domain.enumtype.OrderStatus;
 import async.example.publish.binder.OrderBinder;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import message.OrderMessage;
 import message.OrderRequest;
@@ -16,20 +17,12 @@ import org.springframework.web.client.RestTemplate;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class OrderMqService {
-    RestTemplate restTemplate = new RestTemplate();
-    private static final String paymentUrl = "http://localhost:20002/payment";
+
     private final OrderLogRepository orderLogRepository;
     private final ProductRepository productRepository;
     private final OrderBinder orderBinder;
-
-    public OrderMqService(
-        OrderLogRepository orderLogRepository,
-        ProductRepository productRepository, OrderBinder orderBinder) {
-        this.orderLogRepository = orderLogRepository;
-        this.productRepository = productRepository;
-        this.orderBinder = orderBinder;
-    }
 
     public void orderAsyncMessaging(OrderRequest orderRequest) {
         Product product = productRepository.findById(orderRequest.getProductId())

--- a/order/src/main/java/async/example/service/OrderService.java
+++ b/order/src/main/java/async/example/service/OrderService.java
@@ -67,7 +67,7 @@ public class OrderService {
         }
         return false;
     }
-    
+
     public void orderAsync(OrderRequest orderRequest) {
         Product product = productRepository.findById(orderRequest.getProductId())
             .orElseThrow(() -> new RuntimeException("존재하지 않는 상품입니다."));

--- a/order/src/main/java/async/example/service/OrderService.java
+++ b/order/src/main/java/async/example/service/OrderService.java
@@ -67,38 +67,7 @@ public class OrderService {
         }
         return false;
     }
-
-    @Transactional
-    public void orderUntilSucceed(OrderRequest orderRequest) {
-        Product product = productRepository.findById(orderRequest.getProductId())
-            .orElseThrow(() -> new RuntimeException("존재하지 않는 상품입니다."));
-
-        stockCheck(product.getStock(), orderRequest.getStock());
-
-        log.info("주문 생성중");
-        OrderLog orderLog = OrderLog.builder()
-            .productId(product.getId())
-            .productName(product.getName())
-            .productPrice(product.getPrice())
-            .orderStock(orderRequest.getStock())
-            .status(OrderStatus.WAITING_FOR_PAYMENT)
-            .build();
-        orderLogRepository.save(orderLog);
-        log.info("==========주문 내역 생성=============");
-        // 결제 성공시까지 계속 try
-        Long totalPrice = product.getPrice() * orderRequest.getStock();
-        ResponseEntity<String> response = restTemplate.postForEntity(paymentUrl, totalPrice, String.class);
-        while (response.getBody().equals("실패")) {
-            response = restTemplate.postForEntity(paymentUrl, totalPrice, String.class);
-            log.info(response.getBody());
-        }
-        log.info("결제 성공");
-        product.updateStock(orderRequest.getStock());
-        productRepository.save(product);
-        orderLog.setStatus(OrderStatus.COMPLETE);
-        orderLogRepository.save(orderLog);
-    }
-
+    
     public void orderAsync(OrderRequest orderRequest) {
         Product product = productRepository.findById(orderRequest.getProductId())
             .orElseThrow(() -> new RuntimeException("존재하지 않는 상품입니다."));

--- a/order/src/main/java/async/example/service/OrderSyncService.java
+++ b/order/src/main/java/async/example/service/OrderSyncService.java
@@ -5,7 +5,6 @@ import async.example.domain.entity.Product;
 import async.example.domain.entity.repository.OrderLogRepository;
 import async.example.domain.entity.repository.ProductRepository;
 import async.example.domain.enumtype.OrderStatus;
-import async.example.publish.binder.OrderBinder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import message.OrderRequest;
@@ -21,48 +20,24 @@ public class OrderSyncService {
     RestTemplate restTemplate = new RestTemplate();
     private static final String paymentUrl = "http://localhost:20002/payment";
 
-    private final OrderLogRepository orderLogRepository;
-    private final ProductRepository productRepository;
-    
+    private final CommonService commonService;
+
     @Transactional
     public boolean orderSync(OrderRequest orderRequest) {
-        Product product = productRepository.findById(orderRequest.getProductId())
-            .orElseThrow(() -> new RuntimeException("존재하지 않는 상품입니다."));
+        // before payment
+        Product product = commonService.findProduct(orderRequest.getProductId());
+        int requestStock = orderRequest.getStock();
+        Long totalPrice = product.getPrice() * requestStock;
+        OrderLog orderLog = commonService.checkStockAndCreateOrder(product, requestStock, OrderStatus.WAITING_FOR_PAYMENT);
 
-        stockCheck(product.getStock(), orderRequest.getStock());
-
-        log.info("============주문 생성중==========");
-        OrderLog orderLog = OrderLog.builder()
-            .productId(product.getId())
-            .productName(product.getName())
-            .productPrice(product.getPrice())
-            .orderStock(orderRequest.getStock())
-            .status(OrderStatus.WAITING_FOR_PAYMENT)
-            .build();
-        orderLogRepository.save(orderLog);
-        log.info("==========주문 내역 생성=============");
-        Long totalPrice = product.getPrice() * orderRequest.getStock();
+        // request payment
         ResponseEntity<String> response = restTemplate.postForEntity(paymentUrl, totalPrice, String.class);
         log.info("==========결제 요청 =============");
-        log.info("결제 요청 결과: {}", response.getBody());
         if (response.getBody().equals("성공")) {
-            log.info("결제에 성공했습니다.");
-            product.updateStock(orderRequest.getStock());
-            productRepository.save(product);
-            orderLog.setStatus(OrderStatus.COMPLETE);
-            orderLogRepository.save(orderLog);
+            commonService.updateStockAndSaveOrder(product, requestStock, orderLog);
             return true;
-        } else {
-            log.info("결제에 실패했습니다.");
-            orderLog.setStatus(OrderStatus.FAILED);
         }
+        commonService.saveFailOrder(orderLog);
         return false;
-    }
-
-    private void stockCheck(Integer prodStock, Integer reqStock) {
-        if (prodStock < reqStock) {
-            log.error("재고가 부족합니다.");
-            throw new RuntimeException("재고가 부족합니다.");
-        }
     }
 }

--- a/order/src/main/java/async/example/service/OrderSyncService.java
+++ b/order/src/main/java/async/example/service/OrderSyncService.java
@@ -6,6 +6,7 @@ import async.example.domain.entity.repository.OrderLogRepository;
 import async.example.domain.entity.repository.ProductRepository;
 import async.example.domain.enumtype.OrderStatus;
 import async.example.publish.binder.OrderBinder;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import message.OrderRequest;
 import org.springframework.http.ResponseEntity;
@@ -15,19 +16,14 @@ import org.springframework.web.client.RestTemplate;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class OrderSyncService {
     RestTemplate restTemplate = new RestTemplate();
     private static final String paymentUrl = "http://localhost:20002/payment";
+
     private final OrderLogRepository orderLogRepository;
     private final ProductRepository productRepository;
-
-    public OrderSyncService(
-        OrderLogRepository orderLogRepository,
-        ProductRepository productRepository, OrderBinder orderBinder) {
-        this.orderLogRepository = orderLogRepository;
-        this.productRepository = productRepository;
-    }
-
+    
     @Transactional
     public boolean orderSync(OrderRequest orderRequest) {
         Product product = productRepository.findById(orderRequest.getProductId())

--- a/order/src/main/java/async/example/service/OrderSyncService.java
+++ b/order/src/main/java/async/example/service/OrderSyncService.java
@@ -2,8 +2,6 @@ package async.example.service;
 
 import async.example.domain.entity.OrderLog;
 import async.example.domain.entity.Product;
-import async.example.domain.entity.repository.OrderLogRepository;
-import async.example.domain.entity.repository.ProductRepository;
 import async.example.domain.enumtype.OrderStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/order/src/main/java/async/example/service/OrderSyncService.java
+++ b/order/src/main/java/async/example/service/OrderSyncService.java
@@ -1,0 +1,72 @@
+package async.example.service;
+
+import async.example.domain.entity.OrderLog;
+import async.example.domain.entity.Product;
+import async.example.domain.entity.repository.OrderLogRepository;
+import async.example.domain.entity.repository.ProductRepository;
+import async.example.domain.enumtype.OrderStatus;
+import async.example.publish.binder.OrderBinder;
+import lombok.extern.slf4j.Slf4j;
+import message.OrderRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@Slf4j
+public class OrderSyncService {
+    RestTemplate restTemplate = new RestTemplate();
+    private static final String paymentUrl = "http://localhost:20002/payment";
+    private final OrderLogRepository orderLogRepository;
+    private final ProductRepository productRepository;
+
+    public OrderSyncService(
+        OrderLogRepository orderLogRepository,
+        ProductRepository productRepository, OrderBinder orderBinder) {
+        this.orderLogRepository = orderLogRepository;
+        this.productRepository = productRepository;
+    }
+
+    @Transactional
+    public boolean orderSync(OrderRequest orderRequest) {
+        Product product = productRepository.findById(orderRequest.getProductId())
+            .orElseThrow(() -> new RuntimeException("존재하지 않는 상품입니다."));
+
+        stockCheck(product.getStock(), orderRequest.getStock());
+
+        log.info("============주문 생성중==========");
+        OrderLog orderLog = OrderLog.builder()
+            .productId(product.getId())
+            .productName(product.getName())
+            .productPrice(product.getPrice())
+            .orderStock(orderRequest.getStock())
+            .status(OrderStatus.WAITING_FOR_PAYMENT)
+            .build();
+        orderLogRepository.save(orderLog);
+        log.info("==========주문 내역 생성=============");
+        Long totalPrice = product.getPrice() * orderRequest.getStock();
+        ResponseEntity<String> response = restTemplate.postForEntity(paymentUrl, totalPrice, String.class);
+        log.info("==========결제 요청 =============");
+        log.info("결제 요청 결과: {}", response.getBody());
+        if (response.getBody().equals("성공")) {
+            log.info("결제에 성공했습니다.");
+            product.updateStock(orderRequest.getStock());
+            productRepository.save(product);
+            orderLog.setStatus(OrderStatus.COMPLETE);
+            orderLogRepository.save(orderLog);
+            return true;
+        } else {
+            log.info("결제에 실패했습니다.");
+            orderLog.setStatus(OrderStatus.FAILED);
+        }
+        return false;
+    }
+
+    private void stockCheck(Integer prodStock, Integer reqStock) {
+        if (prodStock < reqStock) {
+            log.error("재고가 부족합니다.");
+            throw new RuntimeException("재고가 부족합니다.");
+        }
+    }
+}


### PR DESCRIPTION
1.
문항마다 service를 분리해서, 각 문항마다 필요로 하는 필드가 잘 구별되도록 했습니다.

2.
이 프로젝트의 핵심은 '다양한 결제 요청 방법' 비교라고 생각해서
비교의 가독성을 높이기 위해

- 결제요청 전 (상품조회, 재고확인, 주문생성)
- 결제성공 후 (성공한 주문내역 저장)

에 공통적으로 사용되는 메소드를 분리했습니다.


3.
공통메소드를 분리하면서 @Transactional 이 제대로 작동하지 않아서 수정할 예정입니다


